### PR TITLE
Remove yum swap cmd

### DIFF
--- a/dockerfile-gluster-centos
+++ b/dockerfile-gluster-centos
@@ -8,7 +8,7 @@ RUN curl -o /etc/yum.repos.d/glusterfs-epel.repo \
 
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm 
 
-RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
+#RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
 
 RUN yum --setopt=tsflags=nodocs -y install xfsprogs nfs-utils nmap-ncat \
     openssh-server openssh-clients attr iputils iproute net-tools \


### PR DESCRIPTION
Remove yum swap, as it fails since fakesystemd isn't valid package.
The original intent (probably) was to have fakesystemd swapped with systemd{,-libs} but thats isn't needed.

Centos has systemd-container{,-libs} included by default which is light weight than systemd{,-libs} &
good enough for systemctl to work for the glusterfs usecase.
